### PR TITLE
Update workflow settings for incubator repository.

### DIFF
--- a/otterdog/eclipse-tracecompass-incubator.jsonnet
+++ b/otterdog/eclipse-tracecompass-incubator.jsonnet
@@ -23,7 +23,7 @@ orgs.newOrg('eclipse-tracecompass-incubator') {
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
       workflows+: {
-        enabled: false,
+        default_workflow_permissions: "read",
       },
     },
   ],


### PR DESCRIPTION
This should enable the workflows which are currently not running, for e.g. org.eclipse.tracecompass.incubator.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>